### PR TITLE
correct URL to Bill Murray image

### DIFF
--- a/index.php
+++ b/index.php
@@ -8,7 +8,7 @@
 
   <p> App backend <?=gethostname()?> </p>
 
-    <img src="http://fillmurray.com/408/287" />
+    <img src="http://www.fillmurray.com/408/287" />
   </body>
 </html>
 


### PR DESCRIPTION
The site that is used for providing Bill Murray placeholder photos, http://www.fillmurray.com/, has moved to the www subdomain, breaking the image from rendering.

https://github.com/leucos/ansible-tuto-demosite/issues/4